### PR TITLE
Display SHA for ErrRefHasChanged error

### DIFF
--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -596,7 +596,7 @@ func (d *DotGit) checkReferenceAndTruncate(f billy.File, old *plumbing.Reference
 		return err
 	}
 	if ref.Hash() != old.Hash() {
-		return fmt.Errorf("reference has changed concurrently")
+		return fmt.Errorf("reference has changed concurrently for %s from %s to %s", old.Name().String(), old.Hash().String(), ref.Hash().String())
 	}
 	_, err = f.Seek(0, io.SeekStart)
 	if err != nil {

--- a/storage/filesystem/dotgit/dotgit_setref.go
+++ b/storage/filesystem/dotgit/dotgit_setref.go
@@ -74,7 +74,7 @@ func (d *DotGit) setRefNorwfs(fileName, content string, old *plumbing.Reference)
 		}
 
 		if ref.Hash() != old.Hash() {
-			return fmt.Errorf("reference has changed concurrently")
+			return fmt.Errorf("reference has changed concurrently for %s from %s to %s", old.Name().String(), old.Hash().String(), ref.Hash().String())
 		}
 	}
 

--- a/storage/memory/storage.go
+++ b/storage/memory/storage.go
@@ -258,7 +258,7 @@ func (r ReferenceStorage) CheckAndSetReference(ref, old *plumbing.Reference) err
 	if old != nil {
 		tmp := r[ref.Name()]
 		if tmp != nil && tmp.Hash() != old.Hash() {
-			return ErrRefHasChanged
+			return fmt.Errorf("%s for %s from %s to %s", ErrRefHasChanged, ref.Name().String(), old.Hash().String(), tmp.Hash().String())
 		}
 	}
 	r[ref.Name()] = ref


### PR DESCRIPTION
For fixing https://github.com/kubernetes/publishing-bot/issues/162

If this lgtm, I will create a PR to point go-git in publishing bot to the `display-sha-for-flake` branch of my fork.

/cc @dims @sttts